### PR TITLE
Lower the  iOS deployment target to 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ WiFiQRCodeKit
 But some reasonable situations that is keeping iOS version lower than iOS 11 can exist.
 
 WiFiQRCodeKit provides the Wi-Fi configuration feature via QR code for the situations.
-It can work with iOS 9.3+.
+It can work with iOS 8.0+.
 
 
 
@@ -34,7 +34,7 @@ pod 'WiFiQRCodeKit', '~> 1.0'
 Requirements
 ------------
 
-- iOS 9.3+
+- iOS 8.0+
 
 And WiFiQRCodeKit requires 2 other libraries:
 
@@ -59,7 +59,7 @@ import WiFiQRCodeKit
 
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
+
     // ...
 
     private let installer = WiFIQRCodeKit.MobileConfig.Installer(

--- a/WiFiQRCodeKit.podspec
+++ b/WiFiQRCodeKit.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   #   * Finally, don't worry about the indent, CocoaPods strips it!
   s.description  = <<-DESC
   WiFiQRCodeKit provides the Wi-Fi configuration feature via QR code for the situations.
-  It can work with iOS 9.3+.
+  It can work with iOS 8.0+.
   DESC
 
   s.homepage     = "https://github.com/Kuniwak/WiFiQRCodeKit"
@@ -65,7 +65,7 @@ Pod::Spec.new do |s|
   #
 
   s.swift_version = "4.1"
-  s.platform      = :ios, "9.3"
+  s.platform      = :ios, "8.0"
 
   #  When using multiple platforms
   # s.ios.deployment_target = "5.0"

--- a/WiFiQRCodeKit.xcodeproj/project.pbxproj
+++ b/WiFiQRCodeKit.xcodeproj/project.pbxproj
@@ -601,7 +601,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = WiFiQRCodeKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kuniwak.WiFiQRCodeKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -624,7 +624,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = WiFiQRCodeKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kuniwak.WiFiQRCodeKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";


### PR DESCRIPTION
Thank you for your greate library.
I want to use it for my app runnnig in iOS8, so I lower the deployment target to 8.0.

Build: Success
Running sample app in iOS8.1: Successful parsing of my Wi-Fi qrcode.